### PR TITLE
Add sign out experience

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -3,7 +3,7 @@
 // Inspired by react-hot-toast library
 import * as React from 'react';
 
-import type { ToastActionElement, ToastProps } from '@/components/ui/toast';
+import type { ToastActionElement, ToastProps } from '../components/ui/toast';
 
 const TOAST_LIMIT = 1;
 const TOAST_REMOVE_DELAY = 1000000;
@@ -155,7 +155,7 @@ function toast({ ...props }: Toast) {
       ...props,
       id,
       open: true,
-      onOpenChange: (open) => {
+      onOpenChange: (open: boolean) => {
         if (!open) dismiss();
       },
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -195,21 +195,12 @@ function App() {
 
       <footer className="border-t border-gray-200 py-4 mt-auto bg-[#f6f8fa]">
         <div className="container mx-auto px-4 text-center text-sm text-gray-500">
-          Generated using{" "}
-          <a
-            href="https://bolt.new"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-blue-600 hover:underline"
-          >
-            bolt.new
-          </a>{" "}
-          by{" "}
+          Made with ❤️ from{" "}
           <a
             href="https://b.dougie.dev"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-blue-600 hover:underline"
+            className="text-gray-600 hover:underline"
           >
             bdougie
           </a>

--- a/src/components/auth-button.tsx
+++ b/src/components/auth-button.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { Button } from "./ui/button";
 import { supabase } from "@/lib/supabase";
-import { LogIn, LogOut, Loader2 } from "lucide-react";
+import { LogIn, LogOut, Loader2, MessageSquare } from "lucide-react";
 import {
   Avatar,
   AvatarImage,
@@ -136,6 +136,21 @@ export function AuthButton() {
               </p>
             </div>
           </DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="cursor-pointer hover:bg-accent p-3 focus:bg-accent focus:outline-none"
+            asChild
+          >
+            <a
+              href="https://github.com/bdougie/pull2press/issues/new"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center"
+            >
+              <MessageSquare className="mr-2 h-4 w-4" />
+              <span>Give feedback</span>
+            </a>
+          </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem
             onClick={handleSignOut}

--- a/src/components/auth-button.tsx
+++ b/src/components/auth-button.tsx
@@ -1,7 +1,12 @@
-import { useState, useEffect } from 'react';
-import { Button } from './ui/button';
-import { supabase } from '@/lib/supabase';
-import { LogIn, LogOut, Loader2 } from 'lucide-react';
+import { useState, useEffect } from "react";
+import { Button } from "./ui/button";
+import { supabase } from "@/lib/supabase";
+import { LogIn, LogOut, Loader2 } from "lucide-react";
+import {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+} from "../../components/ui/avatar";
 
 export function AuthButton() {
   const [loading, setLoading] = useState(false);
@@ -14,7 +19,9 @@ export function AuthButton() {
     });
 
     // Listen for auth changes
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
       setUser(session?.user ?? null);
     });
 
@@ -25,22 +32,22 @@ export function AuthButton() {
     try {
       setLoading(true);
       const { data, error } = await supabase.auth.signInWithOAuth({
-        provider: 'github',
+        provider: "github",
         options: {
           redirectTo: `${window.location.origin}/`,
-          scopes: 'repo',
-        }
+          scopes: "repo",
+        },
       });
 
       if (error) {
-        console.error('Error signing in:', error.message);
+        console.error("Error signing in:", error.message);
         throw error;
       }
 
       // Log the auth response for debugging
-      console.log('Auth response:', data);
+      console.log("Auth response:", data);
     } catch (err) {
-      console.error('Failed to sign in:', err);
+      console.error("Failed to sign in:", err);
     } finally {
       setLoading(false);
     }
@@ -52,28 +59,49 @@ export function AuthButton() {
       const { error } = await supabase.auth.signOut();
       if (error) throw error;
     } catch (err) {
-      console.error('Error signing out:', err);
+      console.error("Error signing out:", err);
     } finally {
       setLoading(false);
     }
   };
 
   if (user) {
+    // Get GitHub username from user metadata
+    const githubUsername =
+      user.user_metadata?.user_name ||
+      user.user_metadata?.preferred_username ||
+      user.user_metadata?.login;
+    const avatarUrl = githubUsername
+      ? `https://github.com/${githubUsername}.png`
+      : null;
+
+    console.log("User metadata:", user.user_metadata); // Debug user metadata
+
     return (
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={handleSignOut}
-        disabled={loading}
-        className="flex items-center gap-2"
-      >
-        {loading ? (
-          <Loader2 className="h-4 w-4 animate-spin" />
-        ) : (
-          <LogOut className="h-4 w-4" />
+      <div className="flex items-center gap-2">
+        {avatarUrl && (
+          <Avatar className="h-8 w-8">
+            <AvatarImage src={avatarUrl} alt={githubUsername} />
+            <AvatarFallback>
+              {githubUsername?.[0]?.toUpperCase() || "U"}
+            </AvatarFallback>
+          </Avatar>
         )}
-        Sign Out
-      </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleSignOut}
+          disabled={loading}
+          className="flex items-center gap-2"
+        >
+          {loading ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <LogOut className="h-4 w-4" />
+          )}
+          Sign Out
+        </Button>
+      </div>
     );
   }
 

--- a/src/components/auth-button.tsx
+++ b/src/components/auth-button.tsx
@@ -7,10 +7,21 @@ import {
   AvatarImage,
   AvatarFallback,
 } from "../../components/ui/avatar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "../../components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import { useToast } from "../../hooks/use-toast";
 
 export function AuthButton() {
   const [loading, setLoading] = useState(false);
   const [user, setUser] = useState<any>(null);
+  const { toast } = useToast();
 
   useEffect(() => {
     // Check current session
@@ -56,10 +67,37 @@ export function AuthButton() {
   const handleSignOut = async () => {
     try {
       setLoading(true);
-      const { error } = await supabase.auth.signOut();
-      if (error) throw error;
+
+      // First check if a session exists to avoid errors
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      // Only attempt to sign out if there's an active session
+      if (session) {
+        const { error } = await supabase.auth.signOut();
+        if (error) throw error;
+      }
+
+      // Always perform these actions, even if there's no session
+      // Manually clear user state
+      setUser(null);
+
+      // Show success toast
+      toast({
+        title: "Signed out successfully",
+        description: "You have been signed out of your account.",
+      });
+
+      // Force reload the page to ensure all auth state is cleared
+      window.location.href = "/";
     } catch (err) {
       console.error("Error signing out:", err);
+      toast({
+        title: "Sign out failed",
+        description: "There was a problem signing you out. Please try again.",
+        variant: "destructive",
+      });
     } finally {
       setLoading(false);
     }
@@ -78,30 +116,44 @@ export function AuthButton() {
     console.log("User metadata:", user.user_metadata); // Debug user metadata
 
     return (
-      <div className="flex items-center gap-2">
-        {avatarUrl && (
-          <Avatar className="h-8 w-8">
-            <AvatarImage src={avatarUrl} alt={githubUsername} />
-            <AvatarFallback>
-              {githubUsername?.[0]?.toUpperCase() || "U"}
-            </AvatarFallback>
-          </Avatar>
-        )}
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={handleSignOut}
-          disabled={loading}
-          className="flex items-center gap-2"
-        >
-          {loading ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <LogOut className="h-4 w-4" />
-          )}
-          Sign Out
-        </Button>
-      </div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button className="flex items-center gap-2 rounded-md px-2 py-1 transition-colors hover:bg-accent focus:outline-none">
+            <Avatar className="h-8 w-8 border border-border">
+              <AvatarImage src={avatarUrl} alt={githubUsername} />
+              <AvatarFallback className="bg-primary/10 text-primary">
+                {githubUsername?.[0]?.toUpperCase() || "U"}
+              </AvatarFallback>
+            </Avatar>
+            <span className="text-sm font-medium">{githubUsername}</span>
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-56 bg-background">
+          <DropdownMenuLabel className="font-normal p-3">
+            <div className="flex flex-col">
+              <p className="text-sm font-medium leading-none">
+                {githubUsername}
+              </p>
+            </div>
+          </DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onClick={handleSignOut}
+            disabled={loading}
+            className={cn(
+              "cursor-pointer hover:bg-destructive/10 p-3 focus:bg-destructive/10 focus:text-destructive focus:outline-none",
+              loading ? "opacity-50 cursor-not-allowed" : ""
+            )}
+          >
+            {loading ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <LogOut className="mr-2 h-4 w-4 text-destructive" />
+            )}
+            <span className="text-destructive">Sign out</span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     );
   }
 

--- a/src/components/auth-button.tsx
+++ b/src/components/auth-button.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { Button } from "./ui/button";
 import { supabase } from "@/lib/supabase";
-import { LogIn, LogOut, Loader2, MessageSquare } from "lucide-react";
+import { LogIn, LogOut, Loader2 } from "lucide-react";
 import {
   Avatar,
   AvatarImage,
@@ -120,12 +120,17 @@ export function AuthButton() {
         <DropdownMenuTrigger asChild>
           <button className="flex items-center gap-2 rounded-md px-2 py-1 transition-colors hover:bg-accent focus:outline-none">
             <Avatar className="h-8 w-8 border border-border">
-              <AvatarImage src={avatarUrl} alt={githubUsername} />
-              <AvatarFallback className="bg-primary/10 text-primary">
-                {githubUsername?.[0]?.toUpperCase() || "U"}
-              </AvatarFallback>
+              {avatarUrl ? (
+                <AvatarImage src={avatarUrl} alt={githubUsername || "User"} />
+              ) : (
+                <AvatarFallback className="bg-primary/10 text-primary">
+                  {githubUsername?.[0]?.toUpperCase() || "U"}
+                </AvatarFallback>
+              )}
             </Avatar>
-            <span className="text-sm font-medium">{githubUsername}</span>
+            <span className="text-sm font-medium">
+              {githubUsername || "User"}
+            </span>
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-56 bg-background">
@@ -147,7 +152,6 @@ export function AuthButton() {
               rel="noopener noreferrer"
               className="flex items-center"
             >
-              <MessageSquare className="mr-2 h-4 w-4" />
               <span>Give feedback</span>
             </a>
           </DropdownMenuItem>

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -23,7 +23,7 @@ interface PullRequestData {
 }
 
 const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY || import.meta.env.VITE_OPENAI_API_KEY,
+  apiKey: import.meta.env.VITE_OPENAI_API_KEY,
   dangerouslyAllowBrowser: true
 });
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
-import './index.css';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
+  </React.StrictMode>
 );


### PR DESCRIPTION
# What is this?

I added a signout experience with an Avatar. This gives the user context that they've connected their github profile, using their github handle and avatar. 

<img width="323" alt="Screenshot 2025-03-22 at 3 44 24 PM" src="https://github.com/user-attachments/assets/69af9b37-d5d6-4c02-a041-373ba0c2b3a2" />

This pull request includes several changes to the `App.tsx` and `auth-button.tsx` files, focusing on improving the user authentication experience and updating some UI elements. The most important changes include the addition of a dropdown menu for user actions, improvements to the sign-out process, and minor formatting adjustments.

### User Authentication and UI Improvements:

* [`src/components/auth-button.tsx`](diffhunk://#diff-8dc727b99794fcd66c08790b13f5ba2b73dbf735bc5018d36a9f85e1b38a7461L1-R24): Added a dropdown menu with user actions, including a sign-out option. Enhanced the sign-out process to check for an active session before attempting to sign out, and added toast notifications for success and failure messages. [[1]](diffhunk://#diff-8dc727b99794fcd66c08790b13f5ba2b73dbf735bc5018d36a9f85e1b38a7461L1-R24) [[2]](diffhunk://#diff-8dc727b99794fcd66c08790b13f5ba2b73dbf735bc5018d36a9f85e1b38a7461L17-R35) [[3]](diffhunk://#diff-8dc727b99794fcd66c08790b13f5ba2b73dbf735bc5018d36a9f85e1b38a7461L28-R61) [[4]](diffhunk://#diff-8dc727b99794fcd66c08790b13f5ba2b73dbf735bc5018d36a9f85e1b38a7461R70-R156)

### Minor Formatting Adjustments:

* [`src/App.tsx`](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L198-R203): Updated the footer text to "Made with ❤️ from bdougie" and changed the link color to gray.
* [`src/lib/openai.ts`](diffhunk://#diff-17f864f84c4b49d3d1da3a920b45f3bcb74d6d295414e24494edad5734f609c7L26-R26): Simplified the OpenAI API key retrieval by removing the fallback to `process.env.OPENAI_API_KEY`.