### PR TITLE
fix: make editor buttons mobile-friendly with icon-only display

### DIFF
--- a/src/components/enhanced-markdown-editor.tsx
+++ b/src/components/enhanced-markdown-editor.tsx
@@ -344,11 +344,11 @@ export default function EnhancedMarkdownEditor({
                 onClick={handleAIEditorClick}
                 variant="outline"
                 size="sm"
-                className="flex items-center gap-2"
+                className="flex items-center gap-2 md:gap-2 px-2 md:px-3"
                 title="Open AI Editor (Cmd+J)"
               >
                 <Sparkles className="h-4 w-4" />
-                AI Editor
+                <span className="hidden sm:inline">AI Editor</span>
               </Button>
               
               {onRegenerate && (
@@ -423,17 +423,18 @@ export default function EnhancedMarkdownEditor({
               <Button
                 variant="outline"
                 onClick={handleCopy}
-                className="flex items-center gap-2"
+                className="flex items-center gap-2 px-2 md:px-3"
+                title="Copy all content to clipboard"
               >
                 {copied ? (
                   <>
                     <Check className="h-4 w-4" />
-                    Copied!
+                    <span className="hidden sm:inline">Copied!</span>
                   </>
                 ) : (
                   <>
                     <Copy className="h-4 w-4" />
-                    Copy
+                    <span className="hidden sm:inline">Copy All</span>
                   </>
                 )}
               </Button>

--- a/src/components/regeneration-dropdown.tsx
+++ b/src/components/regeneration-dropdown.tsx
@@ -114,12 +114,15 @@ export default function RegenerationDropdown({
         size="sm"
         onClick={handleSimpleRegenerate}
         disabled={isRegenerating}
-        className="flex items-center gap-2"
+        className="flex items-center gap-2 px-2 md:px-3"
+        title={isRegenerating ? "Regenerating..." : "Regenerate content"}
       >
         <RefreshCw
           className={`h-4 w-4 ${isRegenerating ? "animate-spin" : ""}`}
         />
-        {isRegenerating ? "Regenerating..." : "Regenerate"}
+        <span className="hidden sm:inline">
+          {isRegenerating ? "Regenerating..." : "Regenerate"}
+        </span>
       </Button>
     );
   }
@@ -132,13 +135,16 @@ export default function RegenerationDropdown({
             variant="outline"
             size="sm"
             disabled={isRegenerating}
-            className="flex items-center gap-2"
+            className="flex items-center gap-2 px-2 md:px-3"
+            title={isRegenerating ? "Regenerating..." : "Regenerate options"}
           >
             <RefreshCw
               className={`h-4 w-4 ${isRegenerating ? "animate-spin" : ""}`}
             />
-            {isRegenerating ? "Regenerating..." : "Regenerate"}
-            <ChevronDown className="h-3 w-3" />
+            <span className="hidden sm:inline">
+              {isRegenerating ? "Regenerating..." : "Regenerate"}
+            </span>
+            <ChevronDown className="h-3 w-3 hidden sm:inline" />
           </Button>
         </DropdownMenuTrigger>
         


### PR DESCRIPTION
Fixes # 30

## Summary
This PR addresses mobile usability issues in the editor by converting buttons to icon-only display on mobile devices.

## Changes
- 📱 Make AI Editor button icon-only on mobile
- 📱 Make Regenerate button icon-only on mobile
- 📋 Enhance Copy button to say "Copy All" and make mobile-friendly
- 🎯 Add responsive padding for better tap targets
- ♿ Add proper title attributes for accessibility

## Testing
- Buttons show icon-only on mobile screens (sm and below)
- Desktop experience unchanged with full text labels
- All existing functionality preserved

Generated with [Claude Code](https://claude.ai/code)